### PR TITLE
check first if a no-tickets error is raised on login page

### DIFF
--- a/src/components/structures/auth/Login.tsx
+++ b/src/components/structures/auth/Login.tsx
@@ -210,7 +210,9 @@ export default class LoginComponent extends React.PureComponent<IProps, IState> 
 
             // Some error strings only apply for logging in
             const usingEmail = username.indexOf("@") > 0;
-            if (error.httpStatus === 400 && usingEmail) {
+            if (error.errcode == 'no_tickets_found') {
+                errorText = "Login failed. Please purchase or assign a ticket to this email address first.";
+            } else if (error.httpStatus === 400 && usingEmail) {
                 errorText = _t('This homeserver does not support login using email address.');
             } else if (error.errcode === 'M_RESOURCE_LIMIT_EXCEEDED') {
                 const errorTop = messageForResourceLimitError(


### PR DESCRIPTION
Upon login.tsx I'm adding a check for a custom errcode and I'm prompting a custom error message. This custom code is sent from the epcon_auth_provider in case the user has no tickets.